### PR TITLE
Drawing undirected graphs

### DIFF
--- a/lib/arrows.js
+++ b/lib/arrows.js
@@ -3,7 +3,8 @@ var util = require("./util");
 module.exports = {
   "default": normal,
   "normal": normal,
-  "vee": vee
+  "vee": vee,
+  "undirected": undirected
 };
 
 function normal(parent, id, edge, type) {
@@ -37,6 +38,24 @@ function vee(parent, id, edge, type) {
 
   var path = marker.append("path")
     .attr("d", "M 0 0 L 10 5 L 0 10 L 4 5 z")
+    .style("stroke-width", 1)
+    .style("stroke-dasharray", "1,0");
+  util.applyStyle(path, edge[type + "Style"]);
+}
+
+function undirected(parent, id, edge, type) {
+  var marker = parent.append("marker")
+    .attr("id", id)
+    .attr("viewBox", "0 0 10 10")
+    .attr("refX", 9)
+    .attr("refY", 5)
+    .attr("markerUnits", "strokeWidth")
+    .attr("markerWidth", 8)
+    .attr("markerHeight", 6)
+    .attr("orient", "auto");
+
+  var path = marker.append("path")
+    .attr("d", "M 0 5 L 10 5")
     .style("stroke-width", 1)
     .style("stroke-dasharray", "1,0");
   util.applyStyle(path, edge[type + "Style"]);


### PR DESCRIPTION
This change facilitates the drawing of undirected graphs. Note this is a visual change only.  The underlying graph remains a directed graph.
Usage: g.setEdge(x, y, {arrowhead: 'undirected'});