### PR TITLE
Adding id attribute for clusters

### DIFF
--- a/lib/create-clusters.js
+++ b/lib/create-clusters.js
@@ -12,6 +12,10 @@ function createClusters(selection, g) {
   svgClusters.enter()
     .append("g")
       .attr("class", "cluster")
+      .attr("id",function(v){
+          var node = g.node(v);
+          return node.id;
+      })
       .style("opacity", 0);
 
   util.applyTransition(svgClusters, g)


### PR DESCRIPTION
When using clusters in mermaid it would simplify life a lot to have a way of finding a cluster in the svg after the rendering. A simple way of achieving this is to add an id to the cluster element. I use this for adding a title to a cluster which is useful for software architecture diagrams etc.

I hope this makes sense and again... **thanks for your great work!**