### PR TITLE
Add var declaration to avoid global variable scope

### DIFF
--- a/lib/label/add-label.js
+++ b/lib/label/add-label.js
@@ -19,6 +19,7 @@ function addLabel(root, node, location) {
   }
 
   var labelBBox = labelSvg.node().getBBox();
+  var y;
   switch(location) {
     case "top":
       y = (-node.height / 2);


### PR DESCRIPTION
When the render method ran, this was creating a naming collision with some minified code that uses dagre-d3.