### PR TITLE
Change to remove deprecated svg call - Chrome 48

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /build
 /dist
 /node_modules
+.idea

--- a/lib/create-edge-paths.js
+++ b/lib/create-edge-paths.js
@@ -88,7 +88,7 @@ function createLine(edge, points) {
 
 function getCoords(elem) {
   var bbox = elem.getBBox(),
-      matrix = elem.getTransformToElement(elem.ownerSVGElement)
+      matrix = elem.getCTM(elem.ownerSVGElement)
         .translate(bbox.width / 2, bbox.height / 2);
   return { x: matrix.e, y: matrix.f };
 }


### PR DESCRIPTION
Chrome 48 has dropped support for getTransformToElement and have recommended getCTM in its replacement.